### PR TITLE
Fix navigation highlighting for "About Us" section and optimize IntersectionObserver

### DIFF
--- a/src/components/Observer.jsx
+++ b/src/components/Observer.jsx
@@ -16,7 +16,7 @@ const SectionObserver = ({ id, className, ...rest }) => {
     // threshold ?: number | number[];
     const intersectionOptions = {
       root: null,
-      threshold: 0.8, // this means 80% viewable
+      threshold: [0.5, 0.8], // Reacts at 50% and 80% visibility
     };
 
     const intersectionObserver = new IntersectionObserver((entries) => {

--- a/src/sections/Aboutus.jsx
+++ b/src/sections/Aboutus.jsx
@@ -12,13 +12,16 @@ const Aboutus = () => {
 
   return (
     <SectionObserver id="aboutus">
-      <div id="aboutus-wrapper" className="flex flex-col 2xl:mt-10">
+      <div
+        id="aboutus-wrapper"
+        className="flex flex-col 2xl:mt-10 lg:pt-10 pt-4"
+      >
         <div className="relative image rounded-lg">
           <Image
             srcSet="/aboutus-small.jpg 400w, /aboutus-medium.jpg 800w, /aboutus.jpg 1200w"
             src="/aboutus.jpg"
             className="object-contain w-full h-full rounded-lg"
-            alt="Gnome Nepal Team gathering in one palce"
+            alt="Gnome Nepal Team gathering in one place"
           />
         </div>
         <div className="about flex flex-col md:gap-4 gap-2 lg:pt-8 pt-4">


### PR DESCRIPTION
This commit resolves navigation highlighting issues for the **"About Us"** section by:

- Adjusting its padding and layout for **improved responsiveness and alignment**.
- Updating the `IntersectionObserver` thresholds to ensure **accurate detection of section visibility**, enhancing the user experience.

## Before
![brave_sKJUJuiXrI](https://github.com/user-attachments/assets/52d9f0ae-6a45-45fb-b61e-f0109505ce9c)

## After
![brave_8WySHTXMjq](https://github.com/user-attachments/assets/dedce42e-385f-4b13-bd78-338de6421f55)

