### PR TITLE
Change observer threshold to 60%

### DIFF
--- a/src/components/Observer.jsx
+++ b/src/components/Observer.jsx
@@ -16,7 +16,7 @@ const SectionObserver = ({ id, className, ...rest }) => {
     // threshold ?: number | number[];
     const intersectionOptions = {
       root: null,
-      threshold: 0.8, // this means 80% viewable
+      threshold: 0.6, // this means 60% viewable
     };
 
     const intersectionObserver = new IntersectionObserver((entries) => {


### PR DESCRIPTION
changed the section observer threshold to 60% so that navigation highlight for #aboutus can be triggered [maybe because the home section takes less height it may appear again in other browsers we could use any other alternatives]