### PR TITLE
Bugfix: About Us Section Not Registering in Navbar

### DIFF
--- a/src/components/Observer.jsx
+++ b/src/components/Observer.jsx
@@ -16,7 +16,7 @@ const SectionObserver = ({ id, className, ...rest }) => {
     // threshold ?: number | number[];
     const intersectionOptions = {
       root: null,
-      threshold: 0.6, // this means 60% viewable
+      threshold: 0.53, //this means 53% viewable
     };
 
     const intersectionObserver = new IntersectionObserver((entries) => {


### PR DESCRIPTION
# 🛠 Fix: SectionObserver Issue with About Us Section  

This pull request addresses [Issue #84](https://github.com/GNOME-Nepal/website/issues/84), which reports a minor bug in the navigation bar. The issue caused the **About Us** section not to register as active when scrolled into view. The problem was likely related to the section's size, as mentioned in the issue discussion.  

## 🔧 Changes  

In **`src/components/Observer.jsx`**, I modified **line 19**:  

```js
const intersectionOptions = {
  root: null,
  threshold: 0.53, // Previously set to 0.6
};
```

## 📌 Notes  

- I initially tested a **0.5 threshold**, but it caused similar issues in other sections.  
- Setting it to **0.53** resolved the issue without breaking functionality elsewhere.  

## 🖥️ System Info  

- **OS:** Windows 11  
- **Browser:** Brave (Vertical Tabs Enabled)  

