### PR TITLE
fixed the path of logo and favicon path

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -10,7 +10,7 @@ import { themes as prismThemes } from "prism-react-renderer";
 const config = {
   title: "GNOME Nepal",
   tagline: "Foster open-source community in Nepal",
-  favicon: "asset/favicon.svg",
+  favicon: "img/favicon.svg",
   url: "https://nepal.gnome.org",
   baseUrl: "/docs/",
   organizationName: "GNOME Nepal",
@@ -72,7 +72,7 @@ const config = {
         style: "dark",
         logo: {
           alt: "GNOME Nepal Logo",
-          src: "asset/logo.png",
+          src: "img/logo.png",
           href: "https://nepal.gnome.org",
         },
         links: [


### PR DESCRIPTION
Previously, the logo and Favicon were not rendering because the path was directing to the wrong asset. I fixed that and now they are showing correctly. 

## Before: 
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/d662017f-1602-49a2-9560-9ed4bc2c01a7" />

<img width="110" alt="image" src="https://github.com/user-attachments/assets/1c839cd1-0bc9-4127-842c-dd8170ae4dda" />


## After: 
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/b1d3b212-d2a5-40fb-9314-2bfe53d8a9a3" />

<img width="110" alt="image" src="https://github.com/user-attachments/assets/6a742d32-d7d9-4109-9f46-dd6703abae9e" />

