### PR TITLE
fixed(footer): update docs links and added navigation back to main site

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -81,14 +81,14 @@ const config = {
             items: [
               {
                 label: "Home",
-                to: "/",
+                to: "https://nepal.gnome.org/#home",
               },
               {
                 label: "About Us",
-                to: "/about",
+                to: "/docs/",
               }, {
                 label: "FAQ",
-                to: "/faq",
+                to: "https://nepal.gnome.org/#faq",
               },
             ],
           },{

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -77,6 +77,21 @@ const config = {
         },
         links: [
           {
+            title: "GNOME Nepal",
+            items: [
+              {
+                label: "Home",
+                to: "/",
+              },
+              {
+                label: "About Us",
+                to: "/about",
+              }, {
+                label: "FAQ",
+                to: "/faq",
+              },
+            ],
+          },{
             title: "Docs",
             items: [
               {

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -81,14 +81,14 @@ const config = {
             items: [
               {
                 label: "Home",
-                to: "https://nepal.gnome.org/#home",
+                href: "https://nepal.gnome.org/#home",
               },
               {
                 label: "About Us",
                 to: "/docs/",
               }, {
                 label: "FAQ",
-                to: "https://nepal.gnome.org/#faq",
+                href: "https://nepal.gnome.org/#faq",
               },
             ],
           },{

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -27,7 +27,7 @@ const Footer = () => {
               <ul className="flex flex-wrap justify-center gap-4 text-sm">
                 <li>
                   <a
-                    href="https://github.com/GNOME-Nepal/website/blob/main/CODE_OF_CONDUCT.md"
+                    href="/docs/general/code_of_conduct"
                     className="text-gray-300 transition-colors"
                   >
                     Code of Conduct
@@ -43,7 +43,7 @@ const Footer = () => {
                 </li>
                 <li>
                   <a
-                    href="https://github.com/GNOME-Nepal/website/blob/main/CONTRIBUTING.md"
+                    href="/docs/general/contributing"
                     className="text-gray-300 transition-colors"
                   >
                     Contributing Guidelines


### PR DESCRIPTION
**Issue1**: The “Contributing Guidelines” and “Code of Conduct” links in the main site footer were pointing directly to GitHub files.
**Fix**: Updated these to use the internal documentation routes: /docs/general/contributing/  && /docs/general/code_of_conduct/


**Issue 2:** The documentation site footer had no links back to the main GNOME Nepal site, making it one-way navigation.
**Fix**: Added quick links to the footer to navigate easily to the main site
