### PR TITLE
Add Core Team Application form and navbar link

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -40,6 +40,7 @@ const Navbar = () => {
     },
     { to: "/session-request", text: "Request a Session", external: false },
     { to: "/sponsor", text: "Become a Sponsor", external: false },
+    { to: "/coreteam", text: "Core Team Application", external: false },
   ];
 
   useEffect(() => {

--- a/src/pages/CoreTeamForm.jsx
+++ b/src/pages/CoreTeamForm.jsx
@@ -1,0 +1,68 @@
+/* eslint no-use-before-define: 0 */
+import React from "react";
+
+const TALLY_SRC = "https://tally.so/widgets/embed.js";
+const TALLY_FORM_URL = "https://tally.so/r/ja95O6";
+
+const CoreTeamForm = () => {
+  React.useEffect(() => {
+    const scriptSelector = `script[src="${TALLY_SRC}"]`;
+
+    const loadTally = () => {
+      if (window.Tally) {
+        window.Tally.loadEmbeds();
+      } else {
+        document
+          .querySelectorAll("iframe[data-tally-src]:not([src])")
+          .forEach((iframeEl) => {
+            iframeEl.src = iframeEl.dataset.tallySrc;
+          });
+      }
+    };
+
+    // If Tally is already loaded, just load the embeds
+    if (window.Tally) {
+      loadTally();
+      return;
+    }
+
+    // If the script is not present, add it
+    if (!document.querySelector(scriptSelector)) {
+      const script = document.createElement("script");
+      script.src = TALLY_SRC;
+      script.onload = loadTally;
+      script.onerror = loadTally;
+      document.body.appendChild(script);
+    } else {
+      // If script is present but not loaded yet, wait for it
+      document
+        .querySelector(scriptSelector)
+        .addEventListener("load", loadTally);
+    }
+
+    return () => {
+      const existingScript = document.querySelector(scriptSelector);
+      if (existingScript) {
+        existingScript.removeEventListener("load", loadTally);
+      }
+    };
+  }, []);
+
+  return (
+    <iframe
+      data-tally-src={TALLY_FORM_URL}
+      width="100%"
+      height="100%"
+      title="GNOME Nepal Leaders Application form"
+      style={{
+        background: "#fff",
+        minHeight: "100vh",
+        minWidth: "100vw",
+        display: "block",
+      }}
+      sandbox="allow-scripts allow-same-origin allow-forms"
+    ></iframe>
+  );
+};
+
+export default CoreTeamForm;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,2 +1,3 @@
 export { default as Hero } from "./Home.jsx";
 export { default as Sponsor } from "./Sponsor.jsx";
+export { default as CoreTeamForm } from "./CoreTeamForm.jsx";

--- a/src/route.jsx
+++ b/src/route.jsx
@@ -1,6 +1,6 @@
 import { useRoutes } from "react-router-dom";
 import NavFoot from "./layout/NavFoot";
-import { Hero, Sponsor } from "./pages";
+import { Hero, Sponsor, CoreTeamForm } from "./pages";
 import NotFound from "./pages/NotFound";
 import SessionRequestForm from "./pages/SessionRequestForm";
 
@@ -22,6 +22,10 @@ export default function Router() {
     {
       path: "/session-request",
       children: [{ path: "", element: <SessionRequestForm /> }],
+    },
+    {
+      path: "/coreteam",
+      children: [{ path: "", element: <CoreTeamForm /> }],
     },
   ]);
 }


### PR DESCRIPTION
## Description
Adds a new Core Team Application form for GNOME Nepal. This PR introduces a dedicated page where users can apply to become core team members using a Tally form embedded in the application. The form is accessible via the `/coreteam` route and can be reached through the "Get Involved" dropdown in the navbar.

## Type of Change
- [ ] Bug fix  
- [x] New feature  
- [ ] Documentation update  
- [ ] Code style update  
- [ ] Performance improvement  
- [ ] Other (please specify)

## Related Issues
NONE

## Testing Details
- Verified the `/coreteam` route renders the Tally form correctly
- Confirmed the navbar "Get Involved" dropdown includes the "Core Team Application" link
- Tested navigation to the form page from the navbar
- Verified the Tally embed script loads and displays the form properly

## Checklist
- [x] Code follows project guidelines and conventions  
- [x] Changes have been tested locally  
- [ ] Relevant documentation has been updated  
- [ ] Linked to an issue (if applicable)  
- [x] No unnecessary files or changes are included  

## Additional Notes
The CoreTeamForm component follows the same pattern as the existing SessionRequestForm, using the Tally embed script for form rendering. The form URL is `https://tally.so/r/ja95O6` for the GNOME Nepal Leaders Application.